### PR TITLE
create-database-worker

### DIFF
--- a/kissen-api/src/main/java/net/kissenpvp/api/base/Kissen.java
+++ b/kissen-api/src/main/java/net/kissenpvp/api/base/Kissen.java
@@ -2,6 +2,7 @@ package net.kissenpvp.api.base;
 
 
 import net.kissenpvp.api.database.ConnectionProvider;
+import net.kissenpvp.api.database.DatabaseQueue;
 import net.kissenpvp.api.database.Repository;
 import net.kissenpvp.api.localization.GlobalLocaleRegistry;
 import net.kissenpvp.api.network.actor.PlayerRepository;
@@ -38,12 +39,13 @@ public interface Kissen {
      */
     @NonNull UUID serverUid();
 
+    @NonNull DatabaseQueue databaseQueue();
 
-    PlayerRepository playerRepository();
+    @NonNull PlayerRepository playerRepository();
 
-    Repository<String, Rank> rankRepository();
+    @NonNull Repository<String, Rank> rankRepository();
 
-    Repository<Integer, Punishment> punishmentRepository();
+    @NonNull Repository<Integer, Punishment> punishmentRepository();
 
-    PunishmentSubscriptionRepository punishmentSubscriptionRepository();
+    @NonNull PunishmentSubscriptionRepository punishmentSubscriptionRepository();
 }

--- a/kissen-api/src/main/java/net/kissenpvp/api/database/DatabaseQueue.java
+++ b/kissen-api/src/main/java/net/kissenpvp/api/database/DatabaseQueue.java
@@ -1,0 +1,12 @@
+package net.kissenpvp.api.database;
+
+import org.jspecify.annotations.NonNull;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+
+public interface DatabaseQueue
+{
+    <T> @NonNull CompletableFuture<T> submit(@NonNull Callable<T> task);
+
+}

--- a/kissen-source/src/main/java/net/kissenpvp/base/KissenCore.java
+++ b/kissen-source/src/main/java/net/kissenpvp/base/KissenCore.java
@@ -75,7 +75,7 @@ public abstract class KissenCore implements Kissen
         return UUID.fromString(content);
     }
 
-    public @NonNull AsyncDatabaseQueue databaseQueue()
+    @Override public @NonNull AsyncDatabaseQueue databaseQueue()
     {
         return databaseQueue;
     }

--- a/kissen-source/src/main/java/net/kissenpvp/base/KissenCore.java
+++ b/kissen-source/src/main/java/net/kissenpvp/base/KissenCore.java
@@ -3,6 +3,7 @@ package net.kissenpvp.base;
 import net.kissenpvp.api.base.Kissen;
 import net.kissenpvp.api.localization.GlobalLocaleRegistry;
 import net.kissenpvp.api.network.actor.ConsoleClient;
+import net.kissenpvp.database.AsyncDatabaseQueue;
 import net.kissenpvp.localization.InternalGlobalLocaleRegistry;
 import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
@@ -26,6 +27,8 @@ public abstract class KissenCore implements Kissen
     private GlobalLocaleRegistry localeRegistry;
     private boolean started;
 
+    private AsyncDatabaseQueue databaseQueue;
+
     public static @NonNull KissenCore getInstance()
     {
         if (Objects.isNull(instance))
@@ -41,6 +44,7 @@ public abstract class KissenCore implements Kissen
     {
         instance = this;
         localeRegistry = new InternalGlobalLocaleRegistry();
+        databaseQueue = new AsyncDatabaseQueue();
 
         try
         {
@@ -50,7 +54,6 @@ public abstract class KissenCore implements Kissen
         {
             log.warn("Can't create serverid.txt directory!", exception);
         }
-
 
         started = true;
     }
@@ -70,6 +73,11 @@ public abstract class KissenCore implements Kissen
 
         String content = Files.readString(UUID_FILE_PATH).trim();
         return UUID.fromString(content);
+    }
+
+    public @NonNull AsyncDatabaseQueue databaseQueue()
+    {
+        return databaseQueue;
     }
 
     @Override public @NonNull GlobalLocaleRegistry localeRegistry()

--- a/kissen-source/src/main/java/net/kissenpvp/database/AsyncDatabaseQueue.java
+++ b/kissen-source/src/main/java/net/kissenpvp/database/AsyncDatabaseQueue.java
@@ -1,0 +1,47 @@
+package net.kissenpvp.database;
+
+import net.kissenpvp.base.KissenCore;
+import org.jspecify.annotations.NonNull;
+
+import java.util.concurrent.*;
+
+public class AsyncDatabaseQueue implements net.kissenpvp.api.database.DatabaseQueue
+{
+    private final ExecutorService executorService;
+
+    public static <T> @NonNull CompletableFuture<T> submitTask(@NonNull Callable<T> task)
+    {
+        return KissenCore.getInstance().databaseQueue().submit(task);
+    }
+
+    public AsyncDatabaseQueue()
+    {
+        this.executorService = Executors.newSingleThreadExecutor();
+    }
+
+    @Override
+    public <T> @NonNull CompletableFuture<T> submit(@NonNull Callable<T> task)
+    {
+        CompletableFuture<T> future = new CompletableFuture<>();
+
+        service().submit(() -> {
+            try {
+                T result = task.call();
+                future.complete(result);
+            } catch (Exception e) {
+                future.completeExceptionally(e);
+            }
+        });
+
+        return future;
+    }
+
+    public void shutdown() {
+        service().shutdown();
+    }
+
+    protected @NonNull ExecutorService service()
+    {
+        return executorService;
+    }
+}

--- a/kissen-source/src/main/java/net/kissenpvp/network/actor/InternalPlayerRepository.java
+++ b/kissen-source/src/main/java/net/kissenpvp/network/actor/InternalPlayerRepository.java
@@ -4,6 +4,7 @@ import com.google.common.base.Preconditions;
 import net.kissenpvp.api.network.actor.PlayerClient;
 import net.kissenpvp.api.network.actor.PlayerRepository;
 import net.kissenpvp.base.KissenCore;
+import net.kissenpvp.database.AsyncDatabaseQueue;
 import net.kissenpvp.database.mariadb.InternalCachedRepository;
 import org.jspecify.annotations.NonNull;
 
@@ -49,7 +50,7 @@ public abstract class InternalPlayerRepository extends InternalCachedRepository<
     @Override protected @NonNull CompletableFuture<Optional<PlayerClient>> findUncached(@NonNull UUID id) throws NullPointerException
     {
         String sql = "SELECT username FROM ksvp_player WHERE id = ?;";
-        return CompletableFuture.supplyAsync(() -> query(sql, (statement ->
+        return AsyncDatabaseQueue.submitTask(() -> query(sql, (statement ->
         {
             statement.setString(1, String.valueOf(id));
             return collectResults(id, statement).stream().findFirst();
@@ -60,7 +61,7 @@ public abstract class InternalPlayerRepository extends InternalCachedRepository<
     {
         String placeHolders = String.join(", ", Collections.nCopies(computeIterableSize(id), "?"));
         String sql = "SELECT id, username FROM ksvp_player WHERE id IN (" + placeHolders + ");";
-        return CompletableFuture.supplyAsync(() -> query(sql, statement ->
+        return AsyncDatabaseQueue.submitTask(() -> query(sql, statement ->
         {
             int index = 1;
             for (UUID current : id)
@@ -74,7 +75,7 @@ public abstract class InternalPlayerRepository extends InternalCachedRepository<
     @Override public @NonNull CompletableFuture<Boolean> has(@NonNull UUID id)
     {
         String sql = "SELECT id FROM ksvp_player WHERE id = ?;";
-        return CompletableFuture.supplyAsync(() -> query(sql, statement ->
+        return AsyncDatabaseQueue.submitTask(() -> query(sql, statement ->
         {
             statement.setString(1, String.valueOf(id));
             return hasResult(statement);
@@ -84,7 +85,7 @@ public abstract class InternalPlayerRepository extends InternalCachedRepository<
     @Override public @NonNull CompletableFuture< Collection<PlayerClient>> findAll()
     {
         String sql = "SELECT id, username FROM ksvp_player;";
-        return CompletableFuture.supplyAsync(() -> query(sql, this::collectResults));
+        return AsyncDatabaseQueue.submitTask(() -> query(sql, this::collectResults));
     }
 
     @Override public @NonNull CompletableFuture<@NonNull Optional<PlayerClient>> findByName(@NonNull String name)
@@ -95,7 +96,7 @@ public abstract class InternalPlayerRepository extends InternalCachedRepository<
     @Override public @NonNull CompletableFuture<@NonNull Optional<UUID>> findLinkId(@NonNull UUID uuid)
     {
         String sql = "SELECT link_id FROM ksvp_player WHERE id = ?;";
-        return CompletableFuture.supplyAsync(() -> assumeNotNull(query(sql, (statement ->
+        return AsyncDatabaseQueue.submitTask(() -> assumeNotNull(query(sql, (statement ->
         {
             statement.setString(1, String.valueOf(uuid));
             try (ResultSet resultSet = statement.executeQuery())
@@ -126,7 +127,7 @@ public abstract class InternalPlayerRepository extends InternalCachedRepository<
         }
 
         String sql = "SELECT id, username FROM ksvp_player WHERE username = ?;";
-        return CompletableFuture.supplyAsync(() -> assumeNotNull(query(sql, (statement ->
+        return AsyncDatabaseQueue.submitTask(() -> assumeNotNull(query(sql, (statement ->
         {
             statement.setString(1, name);
             return collectResults(statement).stream().findFirst();
@@ -167,7 +168,7 @@ public abstract class InternalPlayerRepository extends InternalCachedRepository<
     {
         String placeHolders = String.join(", ", Collections.nCopies(computeIterableSize(name), "?"));
         String sql = "SELECT id, username FROM ksvp_player WHERE username IN (" + placeHolders + ");";
-        return CompletableFuture.supplyAsync(() -> query(sql, statement ->
+        return AsyncDatabaseQueue.submitTask(() -> query(sql, statement ->
         {
             int index = 1;
             for(String current : name)
@@ -209,7 +210,7 @@ public abstract class InternalPlayerRepository extends InternalCachedRepository<
         Preconditions.checkNotNull(id, "id cannot be null");
         String sql = "INSERT INTO ksvp_player (id, link_id, username) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE link_id = ?, username = ?;";
 
-        return CompletableFuture.supplyAsync(() ->
+        return AsyncDatabaseQueue.submitTask(() ->
         {
 
             // we need to insert missing link ids before
@@ -282,7 +283,7 @@ public abstract class InternalPlayerRepository extends InternalCachedRepository<
         Preconditions.checkNotNull(uuid, "The uuid cannot be null!");
 
         String sql = "INSERT INTO ksvp_player_data (server_uid, id, player_data) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE player_data = ?;";
-        return CompletableFuture.supplyAsync(() -> query(sql, statement ->
+        return AsyncDatabaseQueue.submitTask(() -> query(sql, statement ->
         {
             statement.setString(1, String.valueOf(KissenCore.getInstance().serverUid()));
 
@@ -311,7 +312,7 @@ public abstract class InternalPlayerRepository extends InternalCachedRepository<
         Preconditions.checkNotNull(uuid, "The uuid cannot be null!");
 
         String sql = "SELECT player_data FROM ksvp_player_data WHERE server_uid = ? AND id = ?;";
-        return CompletableFuture.supplyAsync(() -> query(sql, statement ->
+        return AsyncDatabaseQueue.submitTask(() -> query(sql, statement ->
         {
             statement.setString(1, String.valueOf(KissenCore.getInstance().serverUid()));
 

--- a/kissen-source/src/main/java/net/kissenpvp/network/actor/rank/repository/InternalRankRepository.java
+++ b/kissen-source/src/main/java/net/kissenpvp/network/actor/rank/repository/InternalRankRepository.java
@@ -2,6 +2,7 @@ package net.kissenpvp.network.actor.rank.repository;
 
 import com.google.common.base.Preconditions;
 import net.kissenpvp.api.network.actor.rank.Rank;
+import net.kissenpvp.database.AsyncDatabaseQueue;
 import net.kissenpvp.database.mariadb.InternalCachedRepository;
 import net.kissenpvp.database.mariadb.InternalRepository;
 import net.kissenpvp.network.actor.rank.InternalRank;
@@ -35,7 +36,7 @@ public class InternalRankRepository extends InternalCachedRepository<String, Ran
     @Override protected @NonNull CompletableFuture<Optional<Rank>> findUncached(@NonNull String id) throws NullPointerException
     {
         String sql = "SELECT priority FROM ksvp_rank WHERE id = ?;";
-        return CompletableFuture.supplyAsync(() -> query(sql, (statement ->
+        return AsyncDatabaseQueue.submitTask(() -> query(sql, (statement ->
         {
             statement.setString(1, id);
             return collectResults(id, statement).stream().findFirst();
@@ -46,7 +47,7 @@ public class InternalRankRepository extends InternalCachedRepository<String, Ran
     {
         String placeHolders = String.join(", ", Collections.nCopies(computeIterableSize(id), "?"));
         String sql = "SELECT id, priority FROM ksvp_rank WHERE id IN (" + placeHolders + ");";
-        return CompletableFuture.supplyAsync(() -> query(sql, (statement ->
+        return AsyncDatabaseQueue.submitTask(() -> query(sql, (statement ->
         {
             int index = 1;
             for (String current : id)
@@ -68,7 +69,7 @@ public class InternalRankRepository extends InternalCachedRepository<String, Ran
 
     @Override public @NonNull CompletableFuture< Collection<Rank>> findAll()
     {
-        return CompletableFuture.supplyAsync(() -> query("SELECT id, priority FROM ksvp_rank;", (statement ->
+        return AsyncDatabaseQueue.submitTask(() -> query("SELECT id, priority FROM ksvp_rank;", (statement ->
         {
             Collection<Rank> rankCollection = new HashSet<>();
             try (ResultSet resultSet = statement.executeQuery())
@@ -84,7 +85,7 @@ public class InternalRankRepository extends InternalCachedRepository<String, Ran
 
     @Override public @NonNull CompletableFuture<Boolean> has(@NonNull String id)
     {
-        return CompletableFuture.supplyAsync(() -> query("SELECT id FROM ksvp_rank WHERE id = ?;", (statement ->
+        return AsyncDatabaseQueue.submitTask(() -> query("SELECT id FROM ksvp_rank WHERE id = ?;", (statement ->
         {
             statement.setString(1, id);
             return hasResult(statement);
@@ -96,7 +97,7 @@ public class InternalRankRepository extends InternalCachedRepository<String, Ran
         Preconditions.checkNotNull(id, "The iterable of ranks cannot be null.");
 
         String sql = "INSERT INTO ksvp_rank (id, priority) VALUES (?, ?) ON DUPLICATE KEY UPDATE priority = ?;";
-        return CompletableFuture.supplyAsync(() -> query(sql, (statement ->
+        return AsyncDatabaseQueue.submitTask(() -> query(sql, (statement ->
         {
             for (Rank rank : id)
             {

--- a/kissen-source/src/main/java/net/kissenpvp/network/actor/rank/repository/InternalRankSubscriptionRepository.java
+++ b/kissen-source/src/main/java/net/kissenpvp/network/actor/rank/repository/InternalRankSubscriptionRepository.java
@@ -5,6 +5,7 @@ import net.kissenpvp.api.network.actor.PlayerClient;
 import net.kissenpvp.api.network.actor.rank.RankSubscription;
 import net.kissenpvp.api.network.actor.rank.RankSubscriptionRepository;
 import net.kissenpvp.api.temporal.WritableTemporalObject;
+import net.kissenpvp.database.AsyncDatabaseQueue;
 import net.kissenpvp.database.mariadb.InternalRepository;
 import net.kissenpvp.network.actor.rank.InternalRankSubscription;
 import net.kissenpvp.temporal.InternalWritableTemporalObject;
@@ -48,7 +49,7 @@ public class InternalRankSubscriptionRepository extends InternalRepository<Strin
     @Override public @NonNull CompletableFuture<@NonNull Optional<RankSubscription>> find(@NonNull String id)
     {
         String sql = "SELECT rank_id, player_id, start_time, expiry, expected_expiry FROM ksvp_rank_subscription WHERE id = ?;";
-        return CompletableFuture.supplyAsync(() -> assumeNotNull(query(sql, (statement ->
+        return AsyncDatabaseQueue.submitTask(() -> assumeNotNull(query(sql, (statement ->
         {
             statement.setString(1, id);
             return collectResults(id, statement).stream().findFirst();
@@ -59,7 +60,7 @@ public class InternalRankSubscriptionRepository extends InternalRepository<Strin
     {
         String placeHolders = String.join(", ", Collections.nCopies(computeIterableSize(id), "?"));
         String sql = "SELECT id, rank_id, player_id, start_time, expiry, expected_expiry FROM ksvp_rank_subscription WHERE id IN (" + placeHolders + ")";
-        return CompletableFuture.supplyAsync(() -> query(sql, statement ->
+        return AsyncDatabaseQueue.submitTask(() -> query(sql, statement ->
         {
             int index = 1;
             for (String current : id)
@@ -74,12 +75,12 @@ public class InternalRankSubscriptionRepository extends InternalRepository<Strin
     @Override public @NonNull CompletableFuture< Collection<RankSubscription>> findAll()
     {
         String sql = "SELECT id, rank_id, player_id, start_time, expiry, expected_expiry FROM ksvp_rank_subscription";
-        return CompletableFuture.supplyAsync(() -> query(sql, this::collectResults));
+        return AsyncDatabaseQueue.submitTask(() -> query(sql, this::collectResults));
     }
 
     @Override public @NonNull CompletableFuture<Boolean> has(@NonNull String id)
     {
-        return CompletableFuture.supplyAsync(() -> query("SELECT id FROM ksvp_rank_subscription WHERE id = ?;", (statement ->
+        return AsyncDatabaseQueue.submitTask(() -> query("SELECT id FROM ksvp_rank_subscription WHERE id = ?;", (statement ->
         {
             statement.setString(1, id);
             return hasResult(statement);
@@ -113,7 +114,7 @@ public class InternalRankSubscriptionRepository extends InternalRepository<Strin
 
         String sql = "INSERT INTO ksvp_rank_subscription (id, rank_id, player_id, start_time, expiry,  expected_expiry) VALUES (?, ?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE rank_id = ?, player_id = ?, expiry = ?;";
 
-        return CompletableFuture.supplyAsync(() -> query(sql, (statement ->
+        return AsyncDatabaseQueue.submitTask(() -> query(sql, (statement ->
         {
             for (RankSubscription subscription : id)
             {
@@ -170,7 +171,7 @@ public class InternalRankSubscriptionRepository extends InternalRepository<Strin
     {
         String sql = "SELECT id, rank_id, player_id, start_time, expiry, expected_expiry FROM ksvp_rank_subscription WHERE player_id = ? AND (expiry IS NULL OR expiry > NOW()) ORDER BY start_time DESC LIMIT 1;";
 
-        return CompletableFuture.supplyAsync(() -> assumeNotNull(query(sql, (statement ->
+        return AsyncDatabaseQueue.submitTask(() -> assumeNotNull(query(sql, (statement ->
         {
             statement.setString(1, String.valueOf(player.id()));
             try(ResultSet resultSet = statement.executeQuery())
@@ -188,7 +189,7 @@ public class InternalRankSubscriptionRepository extends InternalRepository<Strin
     @Override public @NonNull CompletableFuture<@NonNull List<RankSubscription>> findHistory(@NonNull PlayerClient player)
     {
         String sql = "SELECT id, rank_id, player_id, start_time, expiry, expected_expiry FROM ksvp_rank_subscription WHERE player_id = ? ORDER BY start_time DESC;";
-        return CompletableFuture.supplyAsync(() -> assumeNotNull(query(sql, (statement ->
+        return AsyncDatabaseQueue.submitTask(() -> assumeNotNull(query(sql, (statement ->
         {
             statement.setString(1, String.valueOf(player.id()));
 

--- a/kissen-source/src/main/java/net/kissenpvp/punishment/repository/InternalPunishmentRepository.java
+++ b/kissen-source/src/main/java/net/kissenpvp/punishment/repository/InternalPunishmentRepository.java
@@ -4,6 +4,7 @@ import com.google.common.base.Preconditions;
 import net.kissenpvp.api.punishment.Punishment;
 import net.kissenpvp.api.punishment.PunishmentType;
 import net.kissenpvp.api.temporal.timespan.DefinedTimeSpan;
+import net.kissenpvp.database.AsyncDatabaseQueue;
 import net.kissenpvp.database.mariadb.InternalCachedRepository;
 import net.kissenpvp.punishment.InternalPunishment;
 import net.kissenpvp.temporal.timespan.InternalDefinedTimeSpan;
@@ -44,7 +45,7 @@ public class InternalPunishmentRepository extends InternalCachedRepository<Integ
     @Override protected @NonNull CompletableFuture<Optional<Punishment>> findUncached(@NonNull Integer id) throws NullPointerException
     {
         String sql = "SELECT punishment_type, time_span, message FROM ksvp_punishment WHERE id = ?;";
-        return CompletableFuture.supplyAsync(() -> query(sql, statement ->
+        return AsyncDatabaseQueue.submitTask(() -> query(sql, statement ->
         {
             statement.setInt(1, id);
             return collectResults(id, statement).stream().findFirst();
@@ -55,7 +56,7 @@ public class InternalPunishmentRepository extends InternalCachedRepository<Integ
     {
         String placeHolders = String.join(", ", Collections.nCopies(computeIterableSize(id), "?"));
         String sql = "SELECT id, punishment_type, time_span, message FROM ksvp_punishment WHERE id IN (" + placeHolders + ");";
-        return CompletableFuture.supplyAsync(() -> query(sql, statement ->
+        return AsyncDatabaseQueue.submitTask(() -> query(sql, statement ->
         {
             int index = 1;
             for (int current : id)
@@ -70,13 +71,13 @@ public class InternalPunishmentRepository extends InternalCachedRepository<Integ
     @Override public @NonNull CompletableFuture< Collection<Punishment>> findAll()
     {
         String sql = "SELECT id, punishment_type, time_span, message FROM ksvp_punishment;";
-        return CompletableFuture.supplyAsync(() -> query(sql, this::collectResults));
+        return AsyncDatabaseQueue.submitTask(() -> query(sql, this::collectResults));
     }
 
     @Override public @NonNull CompletableFuture<Boolean> has(@NonNull Integer id)
     {
         String sql = "SELECT id FROM ksvp_punishment WHERE id = ?;";
-        return CompletableFuture.supplyAsync(() -> query(sql, statement ->
+        return AsyncDatabaseQueue.submitTask(() -> query(sql, statement ->
         {
             statement.setInt(1, id);
             return hasResult(statement);
@@ -103,7 +104,7 @@ public class InternalPunishmentRepository extends InternalCachedRepository<Integ
         Preconditions.checkNotNull(id, "The punishment iterable cannot be null.");
 
         String sql = "INSERT INTO ksvp_punishment (id, punishment_type, time_span, message) VALUES (?, ?, ?, ?) ON DUPLICATE KEY UPDATE punishment_type = ?, time_span = ?, message = ?;";
-        return CompletableFuture.supplyAsync(() -> query(sql, (statement ->
+        return AsyncDatabaseQueue.submitTask(() -> query(sql, (statement ->
         {
             for (Punishment punishment : id)
             {

--- a/kissen-source/src/main/java/net/kissenpvp/punishment/repository/InternalPunishmentSubscriptionRepository.java
+++ b/kissen-source/src/main/java/net/kissenpvp/punishment/repository/InternalPunishmentSubscriptionRepository.java
@@ -8,6 +8,7 @@ import net.kissenpvp.api.punishment.PunishmentSubscription;
 import net.kissenpvp.api.punishment.PunishmentSubscriptionRepository;
 import net.kissenpvp.api.temporal.WritableTemporalObject;
 import net.kissenpvp.base.KissenCore;
+import net.kissenpvp.database.AsyncDatabaseQueue;
 import net.kissenpvp.database.mariadb.InternalCachedRepository;
 import net.kissenpvp.database.mariadb.InternalRepository;
 import net.kissenpvp.network.actor.InternalPlayerRepository;
@@ -86,7 +87,7 @@ public class InternalPunishmentSubscriptionRepository extends InternalRepository
     @Override public @NonNull CompletableFuture<@NonNull Optional<PunishmentSubscription>> find(@NonNull String id)
     {
         String sql = "SELECT link_id, parent_id, parent_signature, operator_id, start_time, expiry, expected_expiry, message FROM ksvp_punishment_subscription WHERE id = ?;";
-        return CompletableFuture.supplyAsync(() -> assumeNotNull(query(sql, statement ->
+        return AsyncDatabaseQueue.submitTask(() -> assumeNotNull(query(sql, statement ->
         {
             statement.setString(1, id);
             return collectResults(id, statement).stream().findFirst();
@@ -97,7 +98,7 @@ public class InternalPunishmentSubscriptionRepository extends InternalRepository
     {
         String placeHolders = String.join(", ", Collections.nCopies(computeIterableSize(id), "?"));
         String sql = "SELECT id, link_id, parent_id, parent_signature, operator_id, start_time, expiry, expected_expiry, message FROM ksvp_punishment_subscription WHERE id IN (" + placeHolders + ")";
-        return CompletableFuture.supplyAsync(() -> assumeNotNull(query(sql, statement ->
+        return AsyncDatabaseQueue.submitTask(() -> assumeNotNull(query(sql, statement ->
         {
             int index = 1;
             for (String current : id)
@@ -112,13 +113,13 @@ public class InternalPunishmentSubscriptionRepository extends InternalRepository
     @Override public @NonNull CompletableFuture<Collection<PunishmentSubscription>> findAll()
     {
         String sql = "SELECT id, link_id, parent_id, parent_signature, operator_id, start_time, expiry, expected_expiry, message FROM ksvp_punishment_subscription;";
-        return CompletableFuture.supplyAsync(() -> assumeNotNull(query(sql, this::collectResults)));
+        return AsyncDatabaseQueue.submitTask(() -> assumeNotNull(query(sql, this::collectResults)));
     }
 
     @Override public @NonNull CompletableFuture<Boolean> has(@NonNull String id)
     {
         String sql = "SELECT id FROM ksvp_punishment_subscription WHERE id = ?;";
-        return CompletableFuture.supplyAsync(() -> query(sql, statement ->
+        return AsyncDatabaseQueue.submitTask(() -> query(sql, statement ->
         {
             statement.setString(1, id);
             return hasResult(statement);
@@ -131,7 +132,7 @@ public class InternalPunishmentSubscriptionRepository extends InternalRepository
         Preconditions.checkNotNull(id, "The iterable of subscriptions cannot be null.");
 
         String sql = "INSERT INTO ksvp_punishment_subscription (id, link_id, parent_id,  operator_id, start_time, expiry, expected_expiry, message) VALUES (?, ?, ?, ?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE link_id = ?, expiry = ?, message = ?; ";
-        return CompletableFuture.supplyAsync(() -> query(sql, (statement ->
+        return AsyncDatabaseQueue.submitTask(() -> query(sql, (statement ->
         {
             for (PunishmentSubscription subscription : id)
             {
@@ -216,9 +217,8 @@ public class InternalPunishmentSubscriptionRepository extends InternalRepository
     {
         String sql = "SELECT id, username, first_login, last_login, time_played, locale FROM ksvp_player WHERE " +
                 "link_id = ?;";
-        InternalRepository<UUID, PlayerClient> playerRepository =
-                (InternalPlayerRepository) KissenCore.getInstance().playerRepository();
-        return CompletableFuture.supplyAsync(() -> assumeNotNull(query(sql, (statement ->
+        InternalRepository<UUID, PlayerClient> playerRepository = (InternalPlayerRepository) KissenCore.getInstance().playerRepository();
+        return AsyncDatabaseQueue.submitTask(() -> assumeNotNull(query(sql, (statement ->
         {
             statement.setString(1, String.valueOf(linkId));
 
@@ -238,7 +238,7 @@ public class InternalPunishmentSubscriptionRepository extends InternalRepository
     public @NonNull CompletableFuture<@NonNull Collection<UUID>> findTargetIds(@NonNull UUID linkId)
     {
         String sql = "SELECT id FROM ksvp_player WHERE link_id = ?;";
-        return CompletableFuture.supplyAsync(() -> assumeNotNull(query(sql, (statement ->
+        return AsyncDatabaseQueue.submitTask(() -> assumeNotNull(query(sql, (statement ->
         {
 
             statement.setString(1, String.valueOf(linkId));
@@ -259,7 +259,7 @@ public class InternalPunishmentSubscriptionRepository extends InternalRepository
     public @NonNull CompletableFuture<@NonNull Collection<PunishmentSubscription>> findSubscriptions(@NonNull UUID linkId)
     {
         String sql = "SELECT * FROM ksvp_punishment_subscription WHERE link_id = ?;";
-        return CompletableFuture.supplyAsync(() -> assumeNotNull(query(sql, retrieveSubscriptions(linkId))));
+        return AsyncDatabaseQueue.submitTask(() -> assumeNotNull(query(sql, retrieveSubscriptions(linkId))));
     }
 
     @Override
@@ -269,7 +269,7 @@ public class InternalPunishmentSubscriptionRepository extends InternalRepository
     {
         String sql = "SELECT ps.* FROM ksvp_punishment_subscription ps JOIN ksvp_player p ON ps.link_id = p.link_id " +
                 "WHERE p.id = ?;";
-        return CompletableFuture.supplyAsync(() -> assumeNotNull(query(sql, retrieveSubscriptions(userId))));
+        return AsyncDatabaseQueue.submitTask(() -> assumeNotNull(query(sql, retrieveSubscriptions(userId))));
     }
 
     private @NonNull QueryExecutor<Collection<PunishmentSubscription>> retrieveSubscriptions(UUID uuid)


### PR DESCRIPTION

## General
This PR aims to implement a async queue for the database. It reduces the overhead by creating a new thread each time a new database request is send. All database request now will be managed by one single service.

